### PR TITLE
Fixed WampServer displaying question marks instead of characters

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/peropetrol.iml" filepath="$PROJECT_DIR$/.idea/peropetrol.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/peropetrol.iml
+++ b/.idea/peropetrol.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpProjectSharedConfiguration" php_language_level="8.1" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ If MariaDB is the default DBMS, it uses port `3306` and therefore MySQL will use
 Example connection for WampServer & MariaDB: `$conn = mysqli_connect($dbServerName, $dbUsername, $dbPassword, $dbName, '3307');`
 
 Since XAMPP only supports MariaDB there's no need to specify a port: `$conn = mysqli_connect($dbServerName, $dbUsername, $dbPassword, $dbName);`
+
+# Additional information - WampServer charset
+
+The default charset after WampServer's installation seems to be set to `latin1`.
+
+This could potentionally break the application (characters such as `č` would display as `?`), so changing it to `utf8mb4` is advised.
+
+More information can be found in [`dbConn.php`](https://github.com/sinisuba/peropetrol/blob/main/db/dbConn.php).

--- a/db/dbConn.php
+++ b/db/dbConn.php
@@ -11,6 +11,13 @@ $dbName = "peropetrol";
 // Since XAMPP only supports MariaDB there's no need to specify a port.
 $conn = mysqli_connect($dbServerName, $dbUsername, $dbPassword, $dbName);
 
+// Default WampServer charset: 'latin1'
+// Default XAMPP charset: 'utf8mb4'
+// WampServer charset after mysqli_set_charset: 'utf8mb4'
+// In order for the application to work properly while using WampServer, the charset needs to be changed to 'utf8mb4'.
+// XAMPP's default charset is set to 'utf8mb4', so the next step can be avoided.
+mysqli_set_charset($conn, "utf8mb4");
+
 if ($conn === false)
     exit("Greška pri povezivanju na DB '" . $dbName . "' - " . mysqli_connect_error());
 


### PR DESCRIPTION
WampServer was using the latin1 charset, changing this to utf8mb4 fixed the issue.